### PR TITLE
Bug_Win10: Source mode btn font color

### DIFF
--- a/hivacruz.css
+++ b/hivacruz.css
@@ -8,6 +8,7 @@ Version: 0.2
 Tags: dark, blue, typora
 */
 
+
 @font-face {
   font-family: Nunito;
   font-style: normal;
@@ -61,11 +62,9 @@ Tags: dark, blue, typora
   --select-text-bg-color: #192133;
 }
 
-
 .pane-group {
   background-color: var(--bg-color);
 }
-
 
 .dropdown-menu {
   background-color: #1a283d!important;
@@ -723,6 +722,10 @@ p.mathjax-block, .mathjax-block {
 }
 
 #typora-source {
+  color: #555;
+}
+
+.typora-sourceview-on #toggle-sourceview-btn {
   color: #555;
 }
 


### PR DESCRIPTION
Hey, 

Found an issue with the 'Exit Soruce Mode' text color on windows, haven't tested it on OS X. 

Before
![sourceViewBtn](https://user-images.githubusercontent.com/9515726/85220382-4a90bb00-b3ab-11ea-9b25-e140fb93b121.PNG)

After
![sourceViewBtn_fixed](https://user-images.githubusercontent.com/9515726/85220384-4cf31500-b3ab-11ea-972b-dc317b55a8b1.PNG)
