### PR TITLE
Cosmetic: Mermaid diagram styling

### DIFF
--- a/hivacruz.css
+++ b/hivacruz.css
@@ -59,6 +59,10 @@ Tags: dark, blue, typora
   --blur-text-color: rgba(200, 200, 200, 0.33);
   --rawblock-edit-panel-bd: #192133 !important;
 /*  --select-text-bg-color: #192133;*/
+  /* Mermaid diagrams*/
+  --mermaid-node-color: #b87f62 !important; 
+  --mermaid-node-border: #bd7958;
+  --mermaid-contrast-color: #afe61d;
 }
 
 .pane-group {
@@ -1313,3 +1317,71 @@ mark {
     margin-left: 10px;
 }
 
+/* Mermaid Diagrams */
+
+.titleText, .pieTitleText {
+  fill: var(--mermaid-contrast-color);
+  font-size: 2rem;
+  font-family: Nunito,sans-serif;
+  font-weight: 400;
+}
+
+
+/* Node Overview */
+
+/* Node text */ 
+.grid .tick text, .taskText, text.actor, .node .label,
+.taskTextOutsideRight, .taskTextOutsideLeft, .labelText , .loopText {
+  color: var(--text-color);
+  fill: var(--text-color);
+  stroke: black;
+  stroke-width: .05px;
+}
+
+/* Node color */
+.actor, .task, .node rect, 
+.node circle, .node ellipse, .node polygon {
+  fill: var(--mermaid-node-color);
+  stroke: var(--mermaid-node-border);
+  color: var(--text-color);
+}
+
+/* Node Labels (Notes & On path) */
+.edgeLabel foreignObject {
+  color: black;
+  background-color: var(--primary-color);
+  stroke: var(--primary-btn-border-color);
+  stroke-width: 1px;
+  height: 20px;
+  text-align: center;
+  padding-top: 2px;
+}
+
+.note {
+  fill: var(--primary-color);
+  stroke: var(--primary-btn-border-color); 
+}
+
+.noteText {
+  color: var(--text-color);
+}
+
+/* Gantt Specific */
+svg[id^="mermaidChart"] .today {
+  stroke: var(--mermaid-contrast-color);
+}
+
+/* Pie Chart Specific */
+
+svg[id^="mermaidChart"] g path {
+  stroke: var(--text-color);
+}
+
+text.slice {
+  fill: var(--text-color);
+}
+
+.legend text {
+  fill: var(--text-color);
+}
+/* End mermaid */


### PR DESCRIPTION
Hey, 

I saw that mermaid diagrams had defult styling. Did some changes to hopfully make it more visuable within the theme, it's not perfect yet but I think its a bit better. 

### Before changes
![before_p1](https://user-images.githubusercontent.com/9515726/85231831-bfd7ac80-b3fa-11ea-8cf8-7768ace72a0d.PNG)
![before_p2](https://user-images.githubusercontent.com/9515726/85231832-c0704300-b3fa-11ea-9cec-221c2c268f8e.PNG)


### After changes 
![after_p1](https://user-images.githubusercontent.com/9515726/85231840-cf56f580-b3fa-11ea-8a47-60b6eca3ca63.PNG)
![after_p2](https://user-images.githubusercontent.com/9515726/85231841-cfef8c00-b3fa-11ea-80b8-f31b68e98288.PNG)

### Demo markdown file and html export of before and after.

[mermaid_demo_files.zip](https://github.com/kinoute/typora-hivacruz-theme/files/4809994/mermaid_demo_files.zip)

The base colors can be adjusted simple by : 

```  /* Mermaid diagrams*/
  --mermaid-node-color: #b87f62 !important; 
  --mermaid-node-border: #bd7958;
  --mermaid-contrast-color: #afe61d;
```

Edit: the diagrams syntax is directly from mermaidjs documentation